### PR TITLE
feat(builder): Builder pattern support for entities creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 .project
 .classpath
 target/
+*.iml
 *~
 pom.xml.releaseBackup

--- a/README.md
+++ b/README.md
@@ -59,8 +59,9 @@ SensorThingsService service = new SensorThingsService(serviceEndpoint);
 ```
 
 ```java
-Thing thing = new Thing();
-thing.setDescription("I'm a thing!");
+Thing thing = ThingBuilder.builder()
+    .description("I'm a thing!")
+    .build();
 service.create(thing);
 
 // get Thing with numeric id 1234

--- a/src/main/java/de/fraunhofer/iosb/ilt/sta/model/builder/DatastreamBuilder.java
+++ b/src/main/java/de/fraunhofer/iosb/ilt/sta/model/builder/DatastreamBuilder.java
@@ -1,0 +1,24 @@
+package de.fraunhofer.iosb.ilt.sta.model.builder;
+
+import de.fraunhofer.iosb.ilt.sta.model.builder.api.AbstractDatastreamBuilder;
+
+/**
+ * Default {@link de.fraunhofer.iosb.ilt.sta.model.Datastream} {@link de.fraunhofer.iosb.ilt.sta.model.builder.api.Builder}
+ *
+ * @author Aurelien Bourdon
+ */
+public final class DatastreamBuilder extends AbstractDatastreamBuilder<DatastreamBuilder> {
+
+    private DatastreamBuilder() {
+    }
+
+    public static DatastreamBuilder builder() {
+        return new DatastreamBuilder();
+    }
+
+    @Override
+    public DatastreamBuilder getSelf() {
+        return this;
+    }
+
+}

--- a/src/main/java/de/fraunhofer/iosb/ilt/sta/model/builder/FeatureOfInterestBuilder.java
+++ b/src/main/java/de/fraunhofer/iosb/ilt/sta/model/builder/FeatureOfInterestBuilder.java
@@ -1,0 +1,24 @@
+package de.fraunhofer.iosb.ilt.sta.model.builder;
+
+import de.fraunhofer.iosb.ilt.sta.model.builder.api.AbstractFeatureOfInterestBuilder;
+
+/**
+ * Default {@link de.fraunhofer.iosb.ilt.sta.model.FeatureOfInterest} {@link de.fraunhofer.iosb.ilt.sta.model.builder.api.Builder}
+ *
+ * @author Aurelien Bourdon
+ */
+public final class FeatureOfInterestBuilder extends AbstractFeatureOfInterestBuilder<FeatureOfInterestBuilder> {
+
+    private FeatureOfInterestBuilder() {
+    }
+
+    public static FeatureOfInterestBuilder builder() {
+        return new FeatureOfInterestBuilder();
+    }
+
+    @Override
+    public FeatureOfInterestBuilder getSelf() {
+        return this;
+    }
+
+}

--- a/src/main/java/de/fraunhofer/iosb/ilt/sta/model/builder/HistoricalLocationBuilder.java
+++ b/src/main/java/de/fraunhofer/iosb/ilt/sta/model/builder/HistoricalLocationBuilder.java
@@ -1,0 +1,24 @@
+package de.fraunhofer.iosb.ilt.sta.model.builder;
+
+import de.fraunhofer.iosb.ilt.sta.model.builder.api.AbstractHistoricalLocationBuilder;
+
+/**
+ * Default {@link de.fraunhofer.iosb.ilt.sta.model.HistoricalLocation} {@link de.fraunhofer.iosb.ilt.sta.model.builder.api.Builder}
+ *
+ * @author Aurelien Bourdon
+ */
+public final class HistoricalLocationBuilder extends AbstractHistoricalLocationBuilder<HistoricalLocationBuilder> {
+
+    private HistoricalLocationBuilder() {
+    }
+
+    public static HistoricalLocationBuilder builder() {
+        return new HistoricalLocationBuilder();
+    }
+
+    @Override
+    public HistoricalLocationBuilder getSelf() {
+        return this;
+    }
+
+}

--- a/src/main/java/de/fraunhofer/iosb/ilt/sta/model/builder/LocationBuilder.java
+++ b/src/main/java/de/fraunhofer/iosb/ilt/sta/model/builder/LocationBuilder.java
@@ -1,0 +1,24 @@
+package de.fraunhofer.iosb.ilt.sta.model.builder;
+
+import de.fraunhofer.iosb.ilt.sta.model.builder.api.AbstractLocationBuilder;
+
+/**
+ * Default {@link de.fraunhofer.iosb.ilt.sta.model.Location} {@link de.fraunhofer.iosb.ilt.sta.model.builder.api.Builder}
+ *
+ * @author Aurelien Bourdon
+ */
+public final class LocationBuilder extends AbstractLocationBuilder<LocationBuilder> {
+
+    private LocationBuilder() {
+    }
+
+    public static LocationBuilder builder() {
+        return new LocationBuilder();
+    }
+
+    @Override
+    public LocationBuilder getSelf() {
+        return this;
+    }
+
+}

--- a/src/main/java/de/fraunhofer/iosb/ilt/sta/model/builder/MultiDatastreamBuilder.java
+++ b/src/main/java/de/fraunhofer/iosb/ilt/sta/model/builder/MultiDatastreamBuilder.java
@@ -1,0 +1,24 @@
+package de.fraunhofer.iosb.ilt.sta.model.builder;
+
+import de.fraunhofer.iosb.ilt.sta.model.builder.api.AbstractMultiDatastreamBuilder;
+
+/**
+ * Default {@link de.fraunhofer.iosb.ilt.sta.model.MultiDatastream} {@link de.fraunhofer.iosb.ilt.sta.model.builder.api.Builder}
+ *
+ * @author Aurelien Bourdon
+ */
+public final class MultiDatastreamBuilder extends AbstractMultiDatastreamBuilder<MultiDatastreamBuilder> {
+
+    private MultiDatastreamBuilder() {
+    }
+
+    public static MultiDatastreamBuilder builder() {
+        return new MultiDatastreamBuilder();
+    }
+
+    @Override
+    public MultiDatastreamBuilder getSelf() {
+        return this;
+    }
+
+}

--- a/src/main/java/de/fraunhofer/iosb/ilt/sta/model/builder/ObservationBuilder.java
+++ b/src/main/java/de/fraunhofer/iosb/ilt/sta/model/builder/ObservationBuilder.java
@@ -1,0 +1,24 @@
+package de.fraunhofer.iosb.ilt.sta.model.builder;
+
+import de.fraunhofer.iosb.ilt.sta.model.builder.api.AbstractObservationBuilder;
+
+/**
+ * Default {@link de.fraunhofer.iosb.ilt.sta.model.Observation} {@link de.fraunhofer.iosb.ilt.sta.model.builder.api.Builder}
+ *
+ * @author Aurelien Bourdon
+ */
+public final class ObservationBuilder extends AbstractObservationBuilder<ObservationBuilder> {
+
+    private ObservationBuilder() {
+    }
+
+    public static ObservationBuilder builder() {
+        return new ObservationBuilder();
+    }
+
+    @Override
+    public ObservationBuilder getSelf() {
+        return this;
+    }
+
+}

--- a/src/main/java/de/fraunhofer/iosb/ilt/sta/model/builder/ObservedPropertyBuilder.java
+++ b/src/main/java/de/fraunhofer/iosb/ilt/sta/model/builder/ObservedPropertyBuilder.java
@@ -1,0 +1,24 @@
+package de.fraunhofer.iosb.ilt.sta.model.builder;
+
+import de.fraunhofer.iosb.ilt.sta.model.builder.api.AbstractObservedPropertyBuilder;
+
+/**
+ * Default {@link de.fraunhofer.iosb.ilt.sta.model.ObservedProperty} {@link de.fraunhofer.iosb.ilt.sta.model.builder.api.Builder}
+ *
+ * @author Aurelien Bourdon
+ */
+public final class ObservedPropertyBuilder extends AbstractObservedPropertyBuilder<ObservedPropertyBuilder> {
+
+    private ObservedPropertyBuilder() {
+    }
+
+    public static ObservedPropertyBuilder builder() {
+        return new ObservedPropertyBuilder();
+    }
+
+    @Override
+    public ObservedPropertyBuilder getSelf() {
+        return this;
+    }
+
+}

--- a/src/main/java/de/fraunhofer/iosb/ilt/sta/model/builder/SensorBuilder.java
+++ b/src/main/java/de/fraunhofer/iosb/ilt/sta/model/builder/SensorBuilder.java
@@ -1,0 +1,24 @@
+package de.fraunhofer.iosb.ilt.sta.model.builder;
+
+import de.fraunhofer.iosb.ilt.sta.model.builder.api.AbstractSensorBuilder;
+
+/**
+ * Default {@link de.fraunhofer.iosb.ilt.sta.model.Sensor} {@link de.fraunhofer.iosb.ilt.sta.model.builder.api.Builder}
+ *
+ * @author Aurelien Bourdon
+ */
+public final class SensorBuilder extends AbstractSensorBuilder<SensorBuilder> {
+
+    private SensorBuilder() {
+    }
+
+    public static SensorBuilder builder() {
+        return new SensorBuilder();
+    }
+
+    @Override
+    public SensorBuilder getSelf() {
+        return this;
+    }
+
+}

--- a/src/main/java/de/fraunhofer/iosb/ilt/sta/model/builder/ThingBuilder.java
+++ b/src/main/java/de/fraunhofer/iosb/ilt/sta/model/builder/ThingBuilder.java
@@ -1,0 +1,24 @@
+package de.fraunhofer.iosb.ilt.sta.model.builder;
+
+import de.fraunhofer.iosb.ilt.sta.model.builder.api.AbstractThingBuilder;
+
+/**
+ * Default {@link de.fraunhofer.iosb.ilt.sta.model.Thing} {@link de.fraunhofer.iosb.ilt.sta.model.builder.api.Builder}
+ *
+ * @author Aurelien Bourdon
+ */
+public final class ThingBuilder extends AbstractThingBuilder<ThingBuilder> {
+
+    private ThingBuilder() {
+    }
+
+    public static ThingBuilder builder() {
+        return new ThingBuilder();
+    }
+
+    @Override
+    public ThingBuilder getSelf() {
+        return this;
+    }
+
+}

--- a/src/main/java/de/fraunhofer/iosb/ilt/sta/model/builder/api/AbstractDatastreamBuilder.java
+++ b/src/main/java/de/fraunhofer/iosb/ilt/sta/model/builder/api/AbstractDatastreamBuilder.java
@@ -1,0 +1,112 @@
+package de.fraunhofer.iosb.ilt.sta.model.builder.api;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import de.fraunhofer.iosb.ilt.sta.model.Datastream;
+import de.fraunhofer.iosb.ilt.sta.model.Observation;
+import de.fraunhofer.iosb.ilt.sta.model.ObservedProperty;
+import de.fraunhofer.iosb.ilt.sta.model.Sensor;
+import de.fraunhofer.iosb.ilt.sta.model.Thing;
+import de.fraunhofer.iosb.ilt.sta.model.ext.UnitOfMeasurement;
+import org.geojson.Polygon;
+import org.threeten.extra.Interval;
+
+import java.util.List;
+
+/**
+ * Base class for any {@link AbstractEntityBuilder} of {@link Datastream}
+ *
+ * @param <U> the type of the concrete class that extends this {@link AbstractDatastreamBuilder}
+ * @author Aurelien Bourdon
+ */
+public abstract class AbstractDatastreamBuilder<U extends AbstractDatastreamBuilder<U>> extends AbstractEntityBuilder<Datastream, U> {
+
+    @Override
+    protected Datastream newBuildingInstance() {
+        return new Datastream();
+    }
+
+    public U name(final String name) {
+        getBuildingInstance().setName(name);
+        return getSelf();
+    }
+
+    public U description(final String description) {
+        getBuildingInstance().setDescription(description);
+        return getSelf();
+    }
+
+    public U observationType(final ValueCode observationType) {
+        getBuildingInstance().setObservationType(observationType.getValue());
+        return getSelf();
+    }
+
+    public U unitOfMeasurement(final UnitOfMeasurement unitOfMeasurement) {
+        getBuildingInstance().setUnitOfMeasurement(unitOfMeasurement);
+        return getSelf();
+    }
+
+    public U observedArea(final Polygon observedArea) {
+        getBuildingInstance().setObservedArea(observedArea);
+        return getSelf();
+    }
+
+    public U phenomenonTime(final Interval phenomenonTime) {
+        getBuildingInstance().setPhenomenonTime(phenomenonTime);
+        return getSelf();
+    }
+
+    public U resultTime(final Interval resultTime) {
+        getBuildingInstance().setResultTime(resultTime);
+        return getSelf();
+    }
+
+    public U sensor(final Sensor sensor) {
+        getBuildingInstance().setSensor(sensor);
+        return getSelf();
+    }
+
+    public U thing(final Thing thing) {
+        getBuildingInstance().setThing(thing);
+        return getSelf();
+    }
+
+    public U observedProperty(final ObservedProperty observedProperty) {
+        getBuildingInstance().setObservedProperty(observedProperty);
+        return getSelf();
+    }
+
+    public U observations(final List<Observation> observations) {
+        getBuildingInstance().getObservations().addAll(observations);
+        return getSelf();
+    }
+
+    public U observation(final Observation observation) {
+        getBuildingInstance().getObservations().add(observation);
+        return getSelf();
+    }
+
+    /**
+     * All the possible values for a {@link Datastream#observationType} attribute
+     *
+     * @author Aurelien Bourdon
+     */
+    public enum ValueCode {
+        OM_CategoryObservation("http://www.opengis.net/def/observationType/OGC-OM/2.0/OM_CategoryObservation"),
+        OM_CountObservation("http://www.opengis.net/def/observationType/OGC-OM/2.0/OM_CountObservation"),
+        OM_Measurement("http://www.opengis.net/def/observationType/OGC-OM/2.0/OM_Measurement"),
+        OM_Observation("http://www.opengis.net/def/observationType/OGC-OM/2.0/OM_Observation"),
+        OM_TruthObservation("http://www.opengis.net/def/observationType/OGC-OM/2.0/OM_TruthObservation");
+
+        private final String value;
+
+        ValueCode(final String value) {
+            this.value = value;
+        }
+
+        @JsonValue
+        public String getValue() {
+            return value;
+        }
+    }
+
+}

--- a/src/main/java/de/fraunhofer/iosb/ilt/sta/model/builder/api/AbstractEntityBuilder.java
+++ b/src/main/java/de/fraunhofer/iosb/ilt/sta/model/builder/api/AbstractEntityBuilder.java
@@ -1,0 +1,15 @@
+package de.fraunhofer.iosb.ilt.sta.model.builder.api;
+
+import de.fraunhofer.iosb.ilt.sta.model.Entity;
+
+/**
+ * Base class for any {@link EntityBuilder}.
+ * <p>
+ * Any {@link EntityBuilder} is an {@link ExtensibleBuilder}.
+ *
+ * @param <T> the instance class type to build
+ * @param <U> the type of the concrete class that extends this {@link AbstractEntityBuilder}
+ * @author Aurelien Bourdon
+ */
+public abstract class AbstractEntityBuilder<T extends Entity<T>, U extends AbstractEntityBuilder<T, U>> extends ExtensibleBuilder<T, U> implements EntityBuilder<T> {
+}

--- a/src/main/java/de/fraunhofer/iosb/ilt/sta/model/builder/api/AbstractFeatureOfInterestBuilder.java
+++ b/src/main/java/de/fraunhofer/iosb/ilt/sta/model/builder/api/AbstractFeatureOfInterestBuilder.java
@@ -1,0 +1,79 @@
+package de.fraunhofer.iosb.ilt.sta.model.builder.api;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import de.fraunhofer.iosb.ilt.sta.model.FeatureOfInterest;
+import de.fraunhofer.iosb.ilt.sta.model.Observation;
+import org.geojson.GeoJsonObject;
+
+import java.util.List;
+
+/**
+ * Base class for any {@link AbstractEntityBuilder} of {@link FeatureOfInterest}
+ *
+ * @param <U> the type of the concrete class that extends this {@link AbstractFeatureOfInterestBuilder}
+ * @author Aurelien Bourdon
+ */
+public abstract class AbstractFeatureOfInterestBuilder<U extends AbstractFeatureOfInterestBuilder<U>> extends AbstractEntityBuilder<FeatureOfInterest, U> {
+
+    @Override
+    protected FeatureOfInterest newBuildingInstance() {
+        return new FeatureOfInterest();
+    }
+
+    public U name(final String name) {
+        getBuildingInstance().setName(name);
+        return getSelf();
+    }
+
+    public U description(final String description) {
+        getBuildingInstance().setDescription(description);
+        return getSelf();
+    }
+
+    public U encodingType(final ValueCode encodingType) {
+        getBuildingInstance().setEncodingType(encodingType.getValue());
+        return getSelf();
+    }
+
+    public U feature(final Object feature) {
+        if (!(feature instanceof GeoJsonObject)) {
+            throw new BuildingException("Whereas the OGC SensorThings API specifies the FeatureOfInterest#feature as an Any type (so any Object can be used), " +
+                    "the FROST-Client only accepts GeoJSONObject type");
+        }
+        getBuildingInstance().setFeature((GeoJsonObject) feature);
+        return getSelf();
+    }
+
+    public U observations(final List<Observation> observations) {
+        getBuildingInstance().getObservations().addAll(observations);
+        return getSelf();
+    }
+
+    public U observation(final Observation observation) {
+        getBuildingInstance().getObservations().add(observation);
+        return getSelf();
+    }
+
+    /**
+     * All the possible values for a {@link FeatureOfInterest#encodingType} attribute
+     *
+     * @author Aurelien Bourdon
+     */
+    public enum ValueCode {
+
+        GeoJSON("application/vnd.geo+json");
+
+        private final String value;
+
+        ValueCode(final String value) {
+            this.value = value;
+        }
+
+        @JsonValue
+        public String getValue() {
+            return value;
+        }
+
+    }
+
+}

--- a/src/main/java/de/fraunhofer/iosb/ilt/sta/model/builder/api/AbstractHistoricalLocationBuilder.java
+++ b/src/main/java/de/fraunhofer/iosb/ilt/sta/model/builder/api/AbstractHistoricalLocationBuilder.java
@@ -1,0 +1,37 @@
+package de.fraunhofer.iosb.ilt.sta.model.builder.api;
+
+import de.fraunhofer.iosb.ilt.sta.model.HistoricalLocation;
+import de.fraunhofer.iosb.ilt.sta.model.Location;
+import de.fraunhofer.iosb.ilt.sta.model.Thing;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+
+public abstract class AbstractHistoricalLocationBuilder<U extends AbstractHistoricalLocationBuilder<U>> extends AbstractEntityBuilder<HistoricalLocation, U> {
+
+    @Override
+    protected HistoricalLocation newBuildingInstance() {
+        return new HistoricalLocation();
+    }
+
+    public U time(final ZonedDateTime time) {
+        getBuildingInstance().setTime(time);
+        return getSelf();
+    }
+
+    public U thing(final Thing thing) {
+        getBuildingInstance().setThing(thing);
+        return getSelf();
+    }
+
+    public U locations(final List<Location> locations) {
+        getBuildingInstance().getLocations().addAll(locations);
+        return getSelf();
+    }
+
+    public U location(final Location location) {
+        getBuildingInstance().getLocations().add(location);
+        return getSelf();
+    }
+
+}

--- a/src/main/java/de/fraunhofer/iosb/ilt/sta/model/builder/api/AbstractLocationBuilder.java
+++ b/src/main/java/de/fraunhofer/iosb/ilt/sta/model/builder/api/AbstractLocationBuilder.java
@@ -1,0 +1,88 @@
+package de.fraunhofer.iosb.ilt.sta.model.builder.api;
+
+import de.fraunhofer.iosb.ilt.sta.model.HistoricalLocation;
+import de.fraunhofer.iosb.ilt.sta.model.Location;
+import de.fraunhofer.iosb.ilt.sta.model.Thing;
+import org.geojson.GeoJsonObject;
+
+import java.util.List;
+
+/**
+ * Base class for any {@link AbstractEntityBuilder} of {@link Location}
+ *
+ * @param <U> the type of the concrete class that extends this {@link AbstractLocationBuilder}
+ * @author Aurelien Bourdon
+ */
+public abstract class AbstractLocationBuilder<U extends AbstractLocationBuilder<U>> extends AbstractEntityBuilder<Location, U> {
+
+    @Override
+    protected Location newBuildingInstance() {
+        return new Location();
+    }
+
+    public U name(final String name) {
+        getBuildingInstance().setName(name);
+        return getSelf();
+    }
+
+    public U description(final String description) {
+        getBuildingInstance().setDescription(description);
+        return getSelf();
+    }
+
+    public U encodingType(final ValueCode encodingType) {
+        getBuildingInstance().setEncodingType(encodingType.getValue());
+        return getSelf();
+    }
+
+    public U location(final Object location) {
+        if (!(location instanceof GeoJsonObject)) {
+            throw new BuildingException("Whereas the OGC SensorThings API specifies the Location#location as an Any type (so any Object can be used), " +
+                    "the FROST-Client only accepts GeoJSONObject type");
+        }
+        getBuildingInstance().setLocation((GeoJsonObject) location);
+        return getSelf();
+    }
+
+    public U things(final List<Thing> things) {
+        getBuildingInstance().getThings().addAll(things);
+        return getSelf();
+    }
+
+    public U thing(final Thing thing) {
+        getBuildingInstance().getThings().add(thing);
+        return getSelf();
+    }
+
+    public U historicalLocations(final List<HistoricalLocation> historicalLocations) {
+        getBuildingInstance().getHistoricalLocations().addAll(historicalLocations);
+        return getSelf();
+    }
+
+    public U historicalLocation(final HistoricalLocation historicalLocation) {
+        getBuildingInstance().getHistoricalLocations().add(historicalLocation);
+        return getSelf();
+    }
+
+    /**
+     * All the possible values for a {@link Location#encodingType} attribute
+     *
+     * @author Aurelien Bourdon
+     */
+    public enum ValueCode {
+
+        GeoJSON("application/vnd.geo+json");
+
+        private final String value;
+
+        ValueCode(final String value) {
+            this.value = value;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+    }
+
+}

--- a/src/main/java/de/fraunhofer/iosb/ilt/sta/model/builder/api/AbstractMultiDatastreamBuilder.java
+++ b/src/main/java/de/fraunhofer/iosb/ilt/sta/model/builder/api/AbstractMultiDatastreamBuilder.java
@@ -1,0 +1,148 @@
+package de.fraunhofer.iosb.ilt.sta.model.builder.api;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import de.fraunhofer.iosb.ilt.sta.model.MultiDatastream;
+import de.fraunhofer.iosb.ilt.sta.model.Observation;
+import de.fraunhofer.iosb.ilt.sta.model.ObservedProperty;
+import de.fraunhofer.iosb.ilt.sta.model.Sensor;
+import de.fraunhofer.iosb.ilt.sta.model.Thing;
+import de.fraunhofer.iosb.ilt.sta.model.ext.UnitOfMeasurement;
+import org.geojson.Polygon;
+import org.threeten.extra.Interval;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Base class for any {@link AbstractEntityBuilder} of {@link MultiDatastream}
+ *
+ * @param <U> the type of the concrete class that extends this {@link AbstractMultiDatastreamBuilder}
+ * @author Aurelien Bourdon
+ */
+public abstract class AbstractMultiDatastreamBuilder<U extends AbstractMultiDatastreamBuilder<U>> extends AbstractEntityBuilder<MultiDatastream, U> {
+
+    @Override
+    protected MultiDatastream newBuildingInstance() {
+        return new MultiDatastream();
+    }
+
+    @Override
+    public MultiDatastream build() {
+        // A MultiDatastream is always set by the ValueCode#OM_ComplexObservation observation type
+        getBuildingInstance().setObservationType(ValueCode.OM_ComplexObservation.getValue());
+        return super.build();
+    }
+
+    @Override
+    protected MultiDatastream getBuildingInstance() {
+        return new MultiDatastream();
+    }
+
+    public U name(final String name) {
+        getBuildingInstance().setName(name);
+        return getSelf();
+    }
+
+    public U description(final String description) {
+        getBuildingInstance().setDescription(description);
+        return getSelf();
+    }
+
+    public U unitOfMeasurements(final List<UnitOfMeasurement> unitOfMeasurements) {
+        getBuildingInstance().setUnitOfMeasurements(unitOfMeasurements);
+        return getSelf();
+    }
+
+    public U unitOfMeasurement(final UnitOfMeasurement unitOfMeasurement) {
+        if (getBuildingInstance().getUnitOfMeasurements() == null) {
+            getBuildingInstance().setUnitOfMeasurements(new ArrayList<>());
+        }
+        getBuildingInstance().getUnitOfMeasurements().add(unitOfMeasurement);
+        return getSelf();
+    }
+
+    public U observedArea(final Polygon observedArea) {
+        getBuildingInstance().setObservedArea(observedArea);
+        return getSelf();
+    }
+
+    public U phenomenonTime(final Interval phenomenonTime) {
+        getBuildingInstance().setPhenomenonTime(phenomenonTime);
+        return getSelf();
+    }
+
+    public U resultTime(final Interval resultTime) {
+        getBuildingInstance().setResultTime(resultTime);
+        return getSelf();
+    }
+
+    public U multiObservationDataTypes(final List<AbstractDatastreamBuilder.ValueCode> valueCodes) {
+        getBuildingInstance().setMultiObservationDataTypes(
+                valueCodes
+                        .stream()
+                        .map(AbstractDatastreamBuilder.ValueCode::getValue)
+                        .collect(Collectors.toList())
+        );
+        return getSelf();
+    }
+
+    public U multiObservationDataType(final AbstractDatastreamBuilder.ValueCode valueCode) {
+        if (getBuildingInstance().getMultiObservationDataTypes() == null) {
+            getBuildingInstance().setMultiObservationDataTypes(new ArrayList<>());
+        }
+        getBuildingInstance().getMultiObservationDataTypes().add(valueCode.getValue());
+        return getSelf();
+    }
+
+    public U sensor(final Sensor sensor) {
+        getBuildingInstance().setSensor(sensor);
+        return getSelf();
+    }
+
+    public U thing(final Thing thing) {
+        getBuildingInstance().setThing(thing);
+        return getSelf();
+    }
+
+    public U observedProperties(final List<ObservedProperty> observedProperties) {
+        getBuildingInstance().getObservedProperties().addAll(observedProperties);
+        return getSelf();
+    }
+
+    public U observedProperty(final ObservedProperty observedProperty) {
+        getBuildingInstance().getObservedProperties().add(observedProperty);
+        return getSelf();
+    }
+
+    public U observations(final List<Observation> observations) {
+        getBuildingInstance().getObservations().addAll(observations);
+        return getSelf();
+    }
+
+    public U observation(final Observation observation) {
+        getBuildingInstance().getObservations().add(observation);
+        return getSelf();
+    }
+
+    /**
+     * All the possible values for a {@link MultiDatastream#observationType} attribute
+     *
+     * @author Aurelien Bourdon
+     */
+    public enum ValueCode {
+        OM_ComplexObservation("http://www.opengis.net/def/observationType/OGC-OM/2.0/OM_ComplexObservation");
+
+        private final String value;
+
+        ValueCode(final String value) {
+            this.value = value;
+        }
+
+        @JsonValue
+        public String getValue() {
+            return value;
+        }
+    }
+
+}

--- a/src/main/java/de/fraunhofer/iosb/ilt/sta/model/builder/api/AbstractMultiDatastreamBuilder.java
+++ b/src/main/java/de/fraunhofer/iosb/ilt/sta/model/builder/api/AbstractMultiDatastreamBuilder.java
@@ -34,11 +34,6 @@ public abstract class AbstractMultiDatastreamBuilder<U extends AbstractMultiData
         return super.build();
     }
 
-    @Override
-    protected MultiDatastream getBuildingInstance() {
-        return new MultiDatastream();
-    }
-
     public U name(final String name) {
         getBuildingInstance().setName(name);
         return getSelf();

--- a/src/main/java/de/fraunhofer/iosb/ilt/sta/model/builder/api/AbstractObservationBuilder.java
+++ b/src/main/java/de/fraunhofer/iosb/ilt/sta/model/builder/api/AbstractObservationBuilder.java
@@ -1,0 +1,80 @@
+package de.fraunhofer.iosb.ilt.sta.model.builder.api;
+
+import de.fraunhofer.iosb.ilt.sta.model.Datastream;
+import de.fraunhofer.iosb.ilt.sta.model.FeatureOfInterest;
+import de.fraunhofer.iosb.ilt.sta.model.MultiDatastream;
+import de.fraunhofer.iosb.ilt.sta.model.Observation;
+import de.fraunhofer.iosb.ilt.sta.model.TimeObject;
+import org.threeten.extra.Interval;
+
+import java.time.ZonedDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Base class for any {@link AbstractEntityBuilder} of {@link Observation}
+ *
+ * @param <U> the type of the concrete class that extends this {@link AbstractObservationBuilder}
+ * @author Aurelien Bourdon
+ */
+public abstract class AbstractObservationBuilder<U extends AbstractObservationBuilder<U>> extends AbstractEntityBuilder<Observation, U> {
+
+    @Override
+    protected Observation newBuildingInstance() {
+        return new Observation();
+    }
+
+    public U phenomenonTime(final TimeObject phenomenonTime) {
+        getBuildingInstance().setPhenomenonTime(phenomenonTime);
+        return getSelf();
+    }
+
+    public U resultTime(final ZonedDateTime resultTime) {
+        getBuildingInstance().setResultTime(resultTime);
+        return getSelf();
+    }
+
+    public U result(final Object result) {
+        getBuildingInstance().setResult(result);
+        return getSelf();
+    }
+
+    public U resultQuality(final /* DQ_Element */ Object resultQuality) {
+        getBuildingInstance().setResultQuality(resultQuality);
+        return getSelf();
+    }
+
+    public U validTime(final Interval validTime) {
+        getBuildingInstance().setValidTime(validTime);
+        return getSelf();
+    }
+
+    public U parameters(final Map<String, Object> parameters) {
+        getBuildingInstance().setParameters(parameters);
+        return getSelf();
+    }
+
+    public U parameter(final String key, final Object value) {
+        if (getBuildingInstance().getParameters() == null) {
+            getBuildingInstance().setParameters(new HashMap<>());
+        }
+        getBuildingInstance().getParameters().put(key, value);
+        return getSelf();
+    }
+
+    public U datastream(final Datastream datastream) {
+        getBuildingInstance().setDatastream(datastream);
+        return getSelf();
+    }
+
+    public U multiDatastream(final MultiDatastream multiDatastream) {
+        getBuildingInstance().setMultiDatastream(multiDatastream);
+        return getSelf();
+    }
+
+    public U featureOfInterest(final FeatureOfInterest featureOfInterest) {
+        getBuildingInstance().setFeatureOfInterest(featureOfInterest);
+        return getSelf();
+    }
+
+}

--- a/src/main/java/de/fraunhofer/iosb/ilt/sta/model/builder/api/AbstractObservedPropertyBuilder.java
+++ b/src/main/java/de/fraunhofer/iosb/ilt/sta/model/builder/api/AbstractObservedPropertyBuilder.java
@@ -1,0 +1,58 @@
+package de.fraunhofer.iosb.ilt.sta.model.builder.api;
+
+import de.fraunhofer.iosb.ilt.sta.model.Datastream;
+import de.fraunhofer.iosb.ilt.sta.model.MultiDatastream;
+import de.fraunhofer.iosb.ilt.sta.model.ObservedProperty;
+
+import java.net.URI;
+import java.util.List;
+
+/**
+ * Base class for any {@link AbstractEntityBuilder} of {@link ObservedProperty}
+ *
+ * @param <U> the type of the concrete class that extends this {@link AbstractObservedPropertyBuilder}
+ * @author Aurelien Bourdon
+ */
+public abstract class AbstractObservedPropertyBuilder<U extends AbstractObservedPropertyBuilder<U>> extends AbstractEntityBuilder<ObservedProperty, U> {
+
+    @Override
+    protected ObservedProperty newBuildingInstance() {
+        return new ObservedProperty();
+    }
+
+    public U name(final String name) {
+        getBuildingInstance().setName(name);
+        return getSelf();
+    }
+
+    public U definition(final URI definition) {
+        getBuildingInstance().setDefinition(definition.toString());
+        return getSelf();
+    }
+
+    public U description(final String description) {
+        getBuildingInstance().setDescription(description);
+        return getSelf();
+    }
+
+    public U datastreams(final List<Datastream> datastreams) {
+        getBuildingInstance().getDatastreams().addAll(datastreams);
+        return getSelf();
+    }
+
+    public U datastream(final Datastream datastream) {
+        getBuildingInstance().getDatastreams().add(datastream);
+        return getSelf();
+    }
+
+    public U multiDatastreams(final List<MultiDatastream> multiDatastreams) {
+        getBuildingInstance().getMultiDatastreams().addAll(multiDatastreams);
+        return getSelf();
+    }
+
+    public U multiDatastream(final MultiDatastream multiDatastream) {
+        getBuildingInstance().getMultiDatastreams().add(multiDatastream);
+        return getSelf();
+    }
+
+}

--- a/src/main/java/de/fraunhofer/iosb/ilt/sta/model/builder/api/AbstractSensorBuilder.java
+++ b/src/main/java/de/fraunhofer/iosb/ilt/sta/model/builder/api/AbstractSensorBuilder.java
@@ -1,0 +1,84 @@
+package de.fraunhofer.iosb.ilt.sta.model.builder.api;
+
+import de.fraunhofer.iosb.ilt.sta.model.Datastream;
+import de.fraunhofer.iosb.ilt.sta.model.MultiDatastream;
+import de.fraunhofer.iosb.ilt.sta.model.Sensor;
+
+import java.util.List;
+
+/**
+ * Base class for any {@link AbstractEntityBuilder} of {@link Sensor}
+ *
+ * @param <U> the type of the concrete class that extends this {@link AbstractSensorBuilder}
+ * @author Aurelien Bourdon
+ */
+public abstract class AbstractSensorBuilder<U extends AbstractSensorBuilder<U>> extends AbstractEntityBuilder<Sensor, U> {
+
+    @Override
+    protected Sensor newBuildingInstance() {
+        return new Sensor();
+    }
+
+    public U name(final String name) {
+        getBuildingInstance().setName(name);
+        return getSelf();
+    }
+
+    public U description(final String description) {
+        getBuildingInstance().setDescription(description);
+        return getSelf();
+    }
+
+    public U encodingType(final ValueCode encodingType) {
+        getBuildingInstance().setEncodingType(encodingType.getValue());
+        return getSelf();
+    }
+
+    public U metadata(final Object metadata) {
+        getBuildingInstance().setMetadata(metadata);
+        return getSelf();
+    }
+
+    public U datastreams(final List<Datastream> datastreams) {
+        getBuildingInstance().getDatastreams().addAll(datastreams);
+        return getSelf();
+    }
+
+    public U datastream(final Datastream datastream) {
+        getBuildingInstance().getDatastreams().add(datastream);
+        return getSelf();
+    }
+
+    public U multiDatastreams(final List<MultiDatastream> multiDatastreams) {
+        getBuildingInstance().getMultiDatastreams().addAll(multiDatastreams);
+        return getSelf();
+    }
+
+    public U multiDatastream(final MultiDatastream multiDatastream) {
+        getBuildingInstance().getMultiDatastreams().add(multiDatastream);
+        return getSelf();
+    }
+
+    /**
+     * All the possible values for a {@link Sensor#encodingType} attribute
+     *
+     * @author Aurelien Bourdon
+     */
+    public enum ValueCode {
+
+        PDF("application/pdf"),
+        SensorML("http://www.opengis.net/doc/IS/SensorML/2.0");
+
+        private final String value;
+
+        ValueCode(final String value) {
+            this.value = value;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+    }
+
+}

--- a/src/main/java/de/fraunhofer/iosb/ilt/sta/model/builder/api/AbstractThingBuilder.java
+++ b/src/main/java/de/fraunhofer/iosb/ilt/sta/model/builder/api/AbstractThingBuilder.java
@@ -1,0 +1,89 @@
+package de.fraunhofer.iosb.ilt.sta.model.builder.api;
+
+import de.fraunhofer.iosb.ilt.sta.model.Datastream;
+import de.fraunhofer.iosb.ilt.sta.model.HistoricalLocation;
+import de.fraunhofer.iosb.ilt.sta.model.Location;
+import de.fraunhofer.iosb.ilt.sta.model.MultiDatastream;
+import de.fraunhofer.iosb.ilt.sta.model.Thing;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Base class for any {@link AbstractEntityBuilder} of {@link Thing}
+ *
+ * @param <U> the type of the concrete class that extends this {@link AbstractThingBuilder}
+ * @author Aurelien Bourdon
+ */
+public abstract class AbstractThingBuilder<U extends AbstractThingBuilder<U>> extends AbstractEntityBuilder<Thing, U> {
+
+    @Override
+    protected Thing newBuildingInstance() {
+        return new Thing();
+    }
+
+    public U name(final String name) {
+        getBuildingInstance().setName(name);
+        return getSelf();
+    }
+
+    public U description(final String description) {
+        getBuildingInstance().setDescription(description);
+        return getSelf();
+    }
+
+    public U properties(final Map<String, Object> properties) {
+        getBuildingInstance().setProperties(properties);
+        return getSelf();
+    }
+
+    public U property(final String key, final Object value) {
+        if (getBuildingInstance().getProperties() == null) {
+            getBuildingInstance().setProperties(new HashMap<>());
+        }
+        getBuildingInstance().getProperties().put(key, value);
+        return getSelf();
+    }
+
+    public U datastreams(final List<Datastream> datastreams) {
+        getBuildingInstance().getDatastreams().addAll(datastreams);
+        return getSelf();
+    }
+
+    public U multiDatastreams(final List<MultiDatastream> multiDatastreams) {
+        getBuildingInstance().getMultiDatastreams().addAll(multiDatastreams);
+        return getSelf();
+    }
+
+    public U multiDatastream(final MultiDatastream multiDatastream) {
+        getBuildingInstance().getMultiDatastreams().add(multiDatastream);
+        return getSelf();
+    }
+
+    public U datastream(final Datastream datastream) {
+        getBuildingInstance().getDatastreams().add(datastream);
+        return getSelf();
+    }
+
+    public U locations(final List<Location> locations) {
+        getBuildingInstance().getLocations().addAll(locations);
+        return getSelf();
+    }
+
+    public U location(final Location location) {
+        getBuildingInstance().getLocations().add(location);
+        return getSelf();
+    }
+
+    public U historicalLocations(final List<HistoricalLocation> historicalLocations) {
+        getBuildingInstance().getHistoricalLocations().addAll(historicalLocations);
+        return getSelf();
+    }
+
+    public U historicalLocation(final HistoricalLocation historicalLocation) {
+        getBuildingInstance().getHistoricalLocations().add(historicalLocation);
+        return getSelf();
+    }
+
+}

--- a/src/main/java/de/fraunhofer/iosb/ilt/sta/model/builder/api/Builder.java
+++ b/src/main/java/de/fraunhofer/iosb/ilt/sta/model/builder/api/Builder.java
@@ -1,0 +1,18 @@
+package de.fraunhofer.iosb.ilt.sta.model.builder.api;
+
+/**
+ * Base type for any builder
+ *
+ * @param <T> the class type to build
+ * @author Aurelien Bourdon
+ */
+public interface Builder<T> {
+
+    /**
+     * Build the class instance
+     *
+     * @return a new class instance
+     */
+    T build();
+
+}

--- a/src/main/java/de/fraunhofer/iosb/ilt/sta/model/builder/api/BuildingException.java
+++ b/src/main/java/de/fraunhofer/iosb/ilt/sta/model/builder/api/BuildingException.java
@@ -1,0 +1,18 @@
+package de.fraunhofer.iosb.ilt.sta.model.builder.api;
+
+/**
+ * An {@link Exception} during the {@link Builder} process
+ *
+ * @author Aurelien Bourdon
+ */
+public class BuildingException extends RuntimeException {
+
+    public BuildingException(final Throwable cause) {
+        super(cause);
+    }
+
+    public BuildingException(final String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/de/fraunhofer/iosb/ilt/sta/model/builder/api/EntityBuilder.java
+++ b/src/main/java/de/fraunhofer/iosb/ilt/sta/model/builder/api/EntityBuilder.java
@@ -1,0 +1,12 @@
+package de.fraunhofer.iosb.ilt.sta.model.builder.api;
+
+import de.fraunhofer.iosb.ilt.sta.model.Entity;
+
+/**
+ * Base type for any {@link Builder} of {@link Entity}
+ *
+ * @param <T> the {@link Entity} class type to build
+ * @author Aurelien Bourdon
+ */
+public interface EntityBuilder<T extends Entity<T>> extends Builder<T> {
+}

--- a/src/main/java/de/fraunhofer/iosb/ilt/sta/model/builder/api/ExtensibleBuilder.java
+++ b/src/main/java/de/fraunhofer/iosb/ilt/sta/model/builder/api/ExtensibleBuilder.java
@@ -1,0 +1,54 @@
+package de.fraunhofer.iosb.ilt.sta.model.builder.api;
+
+/**
+ * Base class for any {@link Builder} that allows to be inherited to change its behaviour.
+ * <p>
+ * Any {@link ExtensibleBuilder} keeps a reference to the instance under construction.
+ * This reference is created thanks to {@link #newBuildingInstance()} and finally returned when calling {@link #build()}
+ *
+ * @param <T> the instance class type to build
+ * @param <U> the type of the concrete class that extends this {@link ExtensibleBuilder}
+ * @author Aurelien Bourdon
+ */
+public abstract class ExtensibleBuilder<T, U extends ExtensibleBuilder<T, U>> implements Builder<T> {
+
+    private final T buildingInstance;
+
+    protected ExtensibleBuilder() {
+        buildingInstance = newBuildingInstance();
+    }
+
+    /**
+     * Create the new instance that will be build by this {@link ExtensibleBuilder}
+     *
+     * @return the new instance that will be build by this {@link ExtensibleBuilder}
+     */
+    protected abstract T newBuildingInstance();
+
+    /**
+     * Get the reference to the concrete instance that implements this {@link ExtensibleBuilder}
+     *
+     * @return the reference to the concrete instance that implements this {@link ExtensibleBuilder}
+     */
+    protected abstract U getSelf();
+
+    /**
+     * Finalize the build of the instance under construction and get it
+     *
+     * @return the created instance by this {@link ExtensibleBuilder}
+     */
+    @Override
+    public T build() {
+        return buildingInstance;
+    }
+
+    /**
+     * Get the instance under construction
+     *
+     * @return the instance under construction
+     */
+    protected T getBuildingInstance() {
+        return buildingInstance;
+    }
+
+}

--- a/src/main/java/de/fraunhofer/iosb/ilt/sta/model/builder/api/ext/AbstractUnitOfMeasurementBuilder.java
+++ b/src/main/java/de/fraunhofer/iosb/ilt/sta/model/builder/api/ext/AbstractUnitOfMeasurementBuilder.java
@@ -1,0 +1,34 @@
+package de.fraunhofer.iosb.ilt.sta.model.builder.api.ext;
+
+import de.fraunhofer.iosb.ilt.sta.model.builder.api.ExtensibleBuilder;
+import de.fraunhofer.iosb.ilt.sta.model.ext.UnitOfMeasurement;
+
+/**
+ * Base class for any {@link UnitOfMeasurement} builder
+ *
+ * @param <T> the concrete type that extends this {@link AbstractUnitOfMeasurementBuilder}
+ * @author Aurelien Bourdon
+ */
+public abstract class AbstractUnitOfMeasurementBuilder<T extends AbstractUnitOfMeasurementBuilder<T>> extends ExtensibleBuilder<UnitOfMeasurement, T> {
+
+    @Override
+    protected UnitOfMeasurement newBuildingInstance() {
+        return new UnitOfMeasurement();
+    }
+
+    public T name(final String name) {
+        getBuildingInstance().setName(name);
+        return getSelf();
+    }
+
+    public T definition(final String definition) {
+        getBuildingInstance().setDefinition(definition);
+        return getSelf();
+    }
+
+    public T symbol(final String symbol) {
+        getBuildingInstance().setSymbol(symbol);
+        return getSelf();
+    }
+
+}

--- a/src/main/java/de/fraunhofer/iosb/ilt/sta/model/builder/ext/UnitOfMeasurementBuilder.java
+++ b/src/main/java/de/fraunhofer/iosb/ilt/sta/model/builder/ext/UnitOfMeasurementBuilder.java
@@ -1,0 +1,24 @@
+package de.fraunhofer.iosb.ilt.sta.model.builder.ext;
+
+import de.fraunhofer.iosb.ilt.sta.model.builder.api.ext.AbstractUnitOfMeasurementBuilder;
+
+/**
+ * Default {@link de.fraunhofer.iosb.ilt.sta.model.ext.UnitOfMeasurement} {@link de.fraunhofer.iosb.ilt.sta.model.builder.api.Builder}
+ *
+ * @author Aurelien Bourdon
+ */
+public final class UnitOfMeasurementBuilder extends AbstractUnitOfMeasurementBuilder<UnitOfMeasurementBuilder> {
+
+    private UnitOfMeasurementBuilder() {
+    }
+
+    public static UnitOfMeasurementBuilder builder() {
+        return new UnitOfMeasurementBuilder();
+    }
+
+    @Override
+    protected UnitOfMeasurementBuilder getSelf() {
+        return this;
+    }
+
+}


### PR DESCRIPTION
Hi,

Please accept this PR that adds the ability to use the [Builder pattern](https://en.wikipedia.org/wiki/Builder_pattern) during FROST-Client's `Entity` creation:

```java
final Thing thing = ThingBuilder.builder()
  .name("Camera")
  .description("This thing is a camera.")
  .build()
```

In addition, any FROST-Client's entity builder can be extended. This way, FROST-Client clients could define their own way to construct OGC SensorThings' entities (by creating new FROST-Client's entity builders) and so could help to partially extend the FROST-Client's entity model (https://github.com/FraunhoferIOSB/FROST-Client/issues/3):

```java
public final class MyCustomObservationBuilder extends AbstractObservationBuilder<MyCustomObservationBuilder> {

    private MyCustomObservationBuilder() {
    }

    public static MyCustomObservationBuilder builder() {
        return new MyCustomObservationBuilder();
    }

    @Override
    protected MyCustomObservationBuilder getSelf() {
        return this;
    }

    /**
     * Can only handle {@link MyCustomResult} type as Observation#result
     */
    public MyCustomObservationBuilder result(final MyCustomResult result) {
        return super.result(result);
    }

}
```

Finally, this PR includes:
- A new way to construct FROST-Client's entities, by using the Builder pattern
- The ability of any FROST-Client's entity builder to be extended to try to be more compatible with FROST-Client client needs
- A fluent API when using FROST-Client's entity builders
- A fully compliance with the OGC SensorThings' entities specification when using FROST-Client's entity builders interfaces

Regards,
Aurélien
