### PR TITLE
Correctly check relationship between entity type in ExpandedEntity

### DIFF
--- a/src/main/java/de/fraunhofer/iosb/ilt/sta/query/ExpandedEntity.java
+++ b/src/main/java/de/fraunhofer/iosb/ilt/sta/query/ExpandedEntity.java
@@ -20,7 +20,7 @@ public class ExpandedEntity {
 
         for (int i = 0; i < entities.length; i++) {
             if (i > 0) {
-                if (!entities[i].hasRelationTo(entities[i - 1])) {
+                if (!entities[i - 1].hasRelationTo(entities[i])) {
                     throw new InvalidRelationException(
                             String.format("%s is not directly related to %s",
                                     entities[i].getName(),

--- a/src/test/java/de/iosb/fraunhofer/ilt/sta/ExpandedEntityTest.java
+++ b/src/test/java/de/iosb/fraunhofer/ilt/sta/ExpandedEntityTest.java
@@ -1,0 +1,63 @@
+package de.iosb.fraunhofer.ilt.sta;
+
+import de.fraunhofer.iosb.ilt.sta.model.EntityType;
+import de.fraunhofer.iosb.ilt.sta.query.ExpandedEntity;
+import de.fraunhofer.iosb.ilt.sta.query.InvalidRelationException;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.fail;
+
+public class ExpandedEntityTest {
+
+    @Test // Thing/Locations
+    public void testRelation_1_to_n_valid() {
+        try {
+            ExpandedEntity expandedEntity = ExpandedEntity.from(EntityType.THING, EntityType.LOCATIONS);
+            assertEquals(EntityType.THING, expandedEntity.getDirectSibling());
+            assertEquals("Thing/Locations", expandedEntity.toString());
+        } catch (InvalidRelationException e) {
+            fail(e.getMessage());
+        }
+    }
+
+    @Test // Datastream/Sensors (invalid)
+    public void testRelation_1_to_n_invalid() {
+        assertThrows(InvalidRelationException.class,
+                () -> ExpandedEntity.from(EntityType.DATASTREAM, EntityType.SENSORS));
+    }
+
+    @Test // Datastream/Sensor
+    public void testRelation_1_to_1_valid() {
+        try {
+            ExpandedEntity expandedEntity = ExpandedEntity.from(EntityType.DATASTREAM, EntityType.SENSOR);
+            assertEquals(EntityType.DATASTREAM, expandedEntity.getDirectSibling());
+            assertEquals("Datastream/Sensor", expandedEntity.toString());
+        } catch (InvalidRelationException e) {
+            fail(e.getMessage());
+        }
+    }
+
+    @Test // Thing/Datastreams/Sensor
+    public void testRelations_1_to_n_to_1_valid() {
+        try {
+            ExpandedEntity expandedEntity = ExpandedEntity
+                    .from(EntityType.THING, EntityType.DATASTREAMS, EntityType.SENSOR);
+            assertEquals(EntityType.THING, expandedEntity.getDirectSibling());
+            assertEquals("Thing/Datastreams/Sensor", expandedEntity.toString());
+        } catch (InvalidRelationException e) {
+            fail(e.getMessage());
+        }
+    }
+
+    @Test
+    public void testSingleType() {
+        try {
+            ExpandedEntity.from(EntityType.THING);
+        } catch (InvalidRelationException e) {
+            fail(e.getMessage());
+        }
+    }
+
+}


### PR DESCRIPTION
Previously, the relation check used the wrong direction which caused an InvalidRelationException (e.g. THING is related to LOCATIONS, but LOCATIONS is not related to THING).
Fixes #37

The other problems mentioned in the issue aren't covered by this, I'll create another issue for that as there are a few points to discuss.